### PR TITLE
Persist form data across steps and clear on page refresh

### DIFF
--- a/src/daohouse_frontend/src/Components/Dao/Step1.jsx
+++ b/src/daohouse_frontend/src/Components/Dao/Step1.jsx
@@ -46,6 +46,7 @@ const Step1 = ({ setData, setActiveStep,data }) => {
       });
     }
   }, [data]);
+  
 
   // Save data to local storage whenever inputData changes
   useEffect(() => {

--- a/src/daohouse_frontend/src/Components/Dao/Step6.jsx
+++ b/src/daohouse_frontend/src/Components/Dao/Step6.jsx
@@ -78,6 +78,12 @@ const Step6 = ({ data, setData, setActiveStep, handleDaoClick, loadingNext, setL
   };
 
   useEffect(() => {
+    return () => {
+      localStorage.removeItem('step6Data');
+    };
+  }, []);
+
+  useEffect(() => {
     if (shouldCreateDAO) {
       handleDaoClick();
       setShouldCreateDAO(false);

--- a/src/daohouse_frontend/src/pages/CreateDao/CreateDao.jsx
+++ b/src/daohouse_frontend/src/pages/CreateDao/CreateDao.jsx
@@ -29,6 +29,47 @@ const CreateDao = () => {
     },
   });
 
+  useEffect(() => {
+    return () => {
+      localStorage.removeItem('step1Data');
+      localStorage.removeItem('step2Data');
+      localStorage.removeItem('step3Data');
+      localStorage.removeItem('inputData');
+      localStorage.removeItem('step5Data');
+      localStorage.removeItem('step6Data');
+
+      setData({
+        step1: {},
+        step2: {},
+        step3: {},
+        step4: {},
+        step5: {},
+        step6: {
+          imageURI: "",
+        },
+      });
+    };
+  }, []);
+
+
+  useEffect(() => {
+    const clearDataOnUnload = () => {
+      localStorage.removeItem('step1Data');
+      localStorage.removeItem('step2Data');
+      localStorage.removeItem('step3Data');
+      localStorage.removeItem('step4Data');
+      localStorage.removeItem('step5Data');
+      localStorage.removeItem('step6Data');
+    };
+  
+    window.addEventListener('beforeunload', clearDataOnUnload);
+  
+    return () => {
+      window.removeEventListener('beforeunload', clearDataOnUnload);
+    };
+  }, []);
+  
+
   const handleDaoClick = async () => {
     setLoadingNext(true)
     const { step1, step2, step3, step4, step6 } = data;


### PR DESCRIPTION
- Added logic to persist form data in localStorage to ensure data is retained when navigating between steps.
- Implemented `beforeunload` event listener to clear localStorage only when the page is refreshed or closed.
- Ensured that form data is not cleared immediately on 'Save and Next' to maintain state when returning to Step 1.